### PR TITLE
The application was failing to connect to InfluxDB due to a `401 Unau…

### DIFF
--- a/jules_bot/utils/config_manager.py
+++ b/jules_bot/utils/config_manager.py
@@ -1,10 +1,16 @@
 import configparser
+import os
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
+from dotenv import load_dotenv
+
+# Load environment variables from .env file at the start
+load_dotenv()
 
 class ConfigManager:
     """
     A class to manage loading and accessing configuration from a .ini file.
+    It can resolve values from environment variables using the @env/ syntax.
     """
     def __init__(self, config_file: Path = Path('config.ini')):
         """
@@ -17,29 +23,60 @@ class ConfigManager:
             raise FileNotFoundError(f"Configuration file not found: {config_file}")
         self.config.read(config_file)
 
+    def _resolve_value(self, value: str) -> Optional[str]:
+        """
+        Resolves a value from an environment variable if it starts with @env/.
+        """
+        if isinstance(value, str) and value.startswith('@env/'):
+            env_var_name = value[5:]
+            return os.getenv(env_var_name)
+        return value
+
     def get_section(self, section: str) -> Dict[str, str]:
         """
-        Retrieves a section from the configuration as a dictionary.
-        Args:
-            section: The name of the section to retrieve.
-        Returns:
-            A dictionary containing the key-value pairs of the section.
+        Retrieves a section from the configuration as a dictionary, resolving env vars.
         """
         if self.config.has_section(section):
-            return dict(self.config.items(section))
+            section_items = self.config.items(section)
+            return {key: self._resolve_value(value) for key, value in section_items}
         return {}
 
     def get(self, section: str, key: str, fallback: str = None) -> str:
         """
-        Retrieves a specific key from a section.
+        Retrieves a specific key from a section, resolving env vars.
         """
-        return self.config.get(section, key, fallback=fallback)
+        # Get the raw value from configparser
+        value = self.config.get(section, key, fallback=fallback)
+
+        # If the retrieved value is the fallback, don't try to resolve it, just return it.
+        # This can happen if the key does not exist in the .ini file.
+        if value == fallback:
+            return fallback
+
+        return self._resolve_value(value)
 
     def getboolean(self, section: str, key: str, fallback: bool = None) -> bool:
         """
-        Retrieves a specific key from a section as a boolean.
+        Retrieves a specific key from a section as a boolean, resolving env vars.
         """
-        return self.config.getboolean(section, key, fallback=fallback)
+        value = self.get(section, key, fallback=None)
+
+        if value is None:
+            if fallback is not None:
+                return fallback
+            # This mimics configparser's behavior of raising an error if key not found and no fallback
+            raise configparser.NoOptionError(key, section)
+
+        # Evaluate the resolved value
+        if isinstance(value, str):
+            if value.lower() in ('true', '1', 't', 'y', 'yes', 'on'):
+                return True
+            if value.lower() in ('false', '0', 'f', 'n', 'no', 'off'):
+                return False
+
+        # If it's not a known string, it might be an invalid value.
+        # Mimic configparser's error.
+        raise ValueError(f'Not a boolean: {value}')
 
 # Instantiate the config manager for global use
 config_manager = ConfigManager()


### PR DESCRIPTION
…thorized` error. This was caused by the `ConfigManager` not resolving configuration values prefixed with `@env/` from environment variables. Instead, it was passing the literal strings (e.g., `'@env/INFLUXDB_TOKEN'`) as credentials.

This change updates the `ConfigManager` to correctly parse these values. It now detects the `@env/` prefix, extracts the environment variable name, and fetches the corresponding value from `os.environ`.

Additionally, this commit makes the application load the `.env` file automatically by calling `load_dotenv()` when the config module is imported. This ensures that configuration works correctly both when running inside a Docker container (where environment variables are injected by Docker) and when running scripts directly on the local machine for development or testing.