### PR TITLE
Fix(trading): Reset trailing stop when position is at a loss

### DIFF
--- a/jules_bot/bot/trading_bot.py
+++ b/jules_bot/bot/trading_bot.py
@@ -572,6 +572,18 @@ class TradingBot:
                                 position.smart_trailing_highest_profit = net_unrealized_pnl
                                 if new_trail_percentage:
                                     position.current_trail_percentage = new_trail_percentage
+                            elif decision == "DEACTIVATE":
+                                logger.info(f"🔵 {reason}")
+                                self.state_manager.update_trade_smart_trailing_state(
+                                    trade_id=position.trade_id,
+                                    is_active=False,
+                                    highest_profit=Decimal('0'),
+                                    activation_price=None,
+                                    current_trail_percentage=None
+                                )
+                                position.is_smart_trailing_active = False
+                                position.smart_trailing_highest_profit = Decimal('0')
+                                position.smart_trailing_activation_price = None
                             elif decision == "SELL":
                                 logger.info(f"✅ {reason}")
                                 sell_candidates.append((position, "trailing_stop"))


### PR DESCRIPTION
The smart trailing stop was not being reset when a position's profit turned negative. This was because the main trading loop was not handling the "DEACTIVATE" signal returned from the strategy rules.

This commit adds logic to the main loop in `trading_bot.py` to handle the "DEACTIVATE" decision. When this decision is received, it now calls the `state_manager` to update the database, resetting the `is_smart_trailing_active` flag to false and clearing the `smart_trailing_highest_profit` and `smart_trailing_activation_price` fields. This ensures the trailing stop will only re-engage once the position becomes profitable again according to the configured minimum profit threshold.